### PR TITLE
Rename deprecated configuration options in setup.cfg

### DIFF
--- a/robomaster_ros/setup.cfg
+++ b/robomaster_ros/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/robomaster_ros
+script_dir=$base/lib/robomaster_ros
 [install]
-install-scripts=$base/lib/robomaster_ros
+install_scripts=$base/lib/robomaster_ros


### PR DESCRIPTION
Fixed a deprecation warning (script_dir instead of script-dir, install_scripts instead of install-scripts).