### PR TITLE
Add missing dependency

### DIFF
--- a/robomaster_description/package.xml
+++ b/robomaster_description/package.xml
@@ -14,6 +14,7 @@
 
   <exec_depend>xacro</exec_depend>
   <exec_depend>urdf</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Add a missing dependency to joint_state_publisher for the robomaster_description package